### PR TITLE
Added possibility to link a message to multiple issues

### DIFF
--- a/src/Http/Controllers/Git/BitBucketController.php
+++ b/src/Http/Controllers/Git/BitBucketController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Git;
 
+use App\Models\Issue;
 use App\Models\GitProvider;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -55,6 +56,16 @@ class BitBucketController extends GitRemoteProvider
 
             return $message;
         }
+    }
+
+    public function handleIssueCreation($response, $message, $issueTitle){
+        $issue = new Issue();
+        $issue->url = str_replace('api.bitbucket.org/2.0/repositories/','bitbucket.org/',$response['links']['self']['href']);
+        $issue->provider = 'bitbucket';
+        $issue->title = $issueTitle;
+        $issue->message_id = $message->id;
+        $issue->save();
+        return $issue;
     }
 
     /**

--- a/src/Http/Controllers/Git/BitBucketController.php
+++ b/src/Http/Controllers/Git/BitBucketController.php
@@ -58,13 +58,9 @@ class BitBucketController extends GitRemoteProvider
         }
     }
 
-    public function handleIssueCreation($response, $message, $issueTitle){
-        $issue = new Issue();
+    public function handleCreatedIssueUrl($response,&$issue){
         $issue->url = str_replace('api.bitbucket.org/2.0/repositories/','bitbucket.org/',$response['links']['self']['href']);
         $issue->provider = 'bitbucket';
-        $issue->title = $issueTitle;
-        $issue->message_id = $message->id;
-        $issue->save();
         return $issue;
     }
 

--- a/src/Http/Controllers/Git/GitHubController.php
+++ b/src/Http/Controllers/Git/GitHubController.php
@@ -52,13 +52,9 @@ class GitHubController extends GitRemoteProvider
     }
 
 
-    public function handleIssueCreation($response, $message, $issueTitle){
-        $issue = new Issue();
+    public function handleCreatedIssueUrl($response, &$issue){
         $issue->url = $response['html_url'];
         $issue->provider = 'github';
-        $issue->title = $issueTitle;
-        $issue->message_id = $message->id;
-        $issue->save();
         return $issue;
     }
 }

--- a/src/Http/Controllers/Git/GitHubController.php
+++ b/src/Http/Controllers/Git/GitHubController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers\Git;
 
+use App\Models\Issue;
+
 class GitHubController extends GitRemoteProvider
 {
     public function handleProviderIssuesResponse($client, $request, $issue_body)
@@ -47,5 +49,16 @@ class GitHubController extends GitRemoteProvider
             return $message;
         }
 
+    }
+
+
+    public function handleIssueCreation($response, $message, $issueTitle){
+        $issue = new Issue();
+        $issue->url = $response['html_url'];
+        $issue->provider = 'github';
+        $issue->title = $issueTitle;
+        $issue->message_id = $message->id;
+        $issue->save();
+        return $issue;
     }
 }

--- a/src/Http/Controllers/Git/GitLabController.php
+++ b/src/Http/Controllers/Git/GitLabController.php
@@ -47,13 +47,9 @@ class GitLabController extends GitRemoteProvider
 
     }
 
-    public function handleIssueCreation($response, $message, $issueTitle){
-        $issue = new Issue();
+    public function handleCreatedIssueUrl($response, &$issue){
         $issue->url = $response['web_url'];
         $issue->provider = 'gitlab';
-        $issue->title = $issueTitle;
-        $issue->message_id = $message->id;
-        $issue->save();
         return $issue;
     }
 }

--- a/src/Http/Controllers/Git/GitLabController.php
+++ b/src/Http/Controllers/Git/GitLabController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers\Git;
 
+use App\Models\Issue;
+
 class GitLabController extends GitRemoteProvider
 {
     public function handleProviderIssuesResponse($client, $request, $issue_body)
@@ -43,5 +45,15 @@ class GitLabController extends GitRemoteProvider
             return $message;
         }
 
+    }
+
+    public function handleIssueCreation($response, $message, $issueTitle){
+        $issue = new Issue();
+        $issue->url = $response['web_url'];
+        $issue->provider = 'gitlab';
+        $issue->title = $issueTitle;
+        $issue->message_id = $message->id;
+        $issue->save();
+        return $issue;
     }
 }

--- a/src/Http/Controllers/Git/GitRemoteProvider.php
+++ b/src/Http/Controllers/Git/GitRemoteProvider.php
@@ -2,10 +2,11 @@
 
 namespace App\Http\Controllers\Git;
 
-use App\Models\GitProvider;
+use App\Models\Issue;
 use App\Models\Message;
-use Illuminate\Http\JsonResponse;
+use App\Models\GitProvider;
 use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
@@ -98,7 +99,7 @@ abstract class GitRemoteProvider
         $repoUrl = $this->getProviderRepositoriesUrl($request);
 
         if (!$repoUrl) {
-            throw new Exception('Error Processing Request, missing Repositories URL', 1);
+            throw new \Exception('Error Processing Request, missing Repositories URL', 1);
         }
         //dd($repoUrl);
         // Send the request to the provider's API
@@ -139,13 +140,11 @@ abstract class GitRemoteProvider
         if there is an error then the response json should return an error instead of the whole response*/
         $response_body = json_decode($response->getBody(), true);
         //dd($response_body);
-        $this->handleIssueCreation($response, $message,$request->issue_summary);
-        // if (isset($response['html_url'])) {
-        //     $issue_url = $response_body['html_url'];
-        //     $message->is_issue = true;
-        //     $message->issue_url = $issue_url;
-        //     $message->save();
-        // }
+        $issue = new Issue();
+        $issue->title = $request->issue_summary;
+        $issue->message_id = $message->id;
+        $this->handleCreatedIssueUrl($response, $issue);
+        $issue->save();
 
         return response()->json([
             'success' => true,
@@ -184,12 +183,12 @@ abstract class GitRemoteProvider
 
 
     /**
-     * Create the issue saving the link and the provvider
+     * Handle the different url behaviour for the created issue
      * @param Response $response
-     * @param Message $message
+     * @param Issue $issue
      * @return Issue
      */
-    abstract protected function handleIssueCreation($response, $message, $issueTitle);
+    abstract protected function handleCreatedIssueUrl($response, &$issue);
 
     // Protected Methods
 

--- a/src/Http/Controllers/Git/GitRemoteProvider.php
+++ b/src/Http/Controllers/Git/GitRemoteProvider.php
@@ -139,12 +139,13 @@ abstract class GitRemoteProvider
         if there is an error then the response json should return an error instead of the whole response*/
         $response_body = json_decode($response->getBody(), true);
         //dd($response_body);
-        if (isset($response['html_url'])) {
-            $issue_url = $response_body['html_url'];
-            $message->is_issue = true;
-            $message->issue_url = $issue_url;
-            $message->save();
-        }
+        $this->handleIssueCreation($response, $message,$request->issue_summary);
+        // if (isset($response['html_url'])) {
+        //     $issue_url = $response_body['html_url'];
+        //     $message->is_issue = true;
+        //     $message->issue_url = $issue_url;
+        //     $message->save();
+        // }
 
         return response()->json([
             'success' => true,
@@ -180,6 +181,15 @@ abstract class GitRemoteProvider
      * @return array
      */
     abstract protected function handle_repositories_mapping($repositories);
+
+
+    /**
+     * Create the issue saving the link and the provvider
+     * @param Response $response
+     * @param Message $message
+     * @return Issue
+     */
+    abstract protected function handleIssueCreation($response, $message, $issueTitle);
 
     // Protected Methods
 

--- a/src/Models/Issue.php
+++ b/src/Models/Issue.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Message;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Issue extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    public function message(): BelongsTo
+    {
+        return $this->belongsTo(Message::class);
+    }
+}

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -6,6 +6,8 @@ use App\Models\Conversation;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
 class Message extends Model
 {
     use HasFactory;
@@ -18,5 +20,16 @@ class Message extends Model
 public function conversation(): BelongsTo
 {
     return $this->belongsTo(Conversation::class);
+}
+
+
+/**
+ * Get the issues opened with this message
+ * 
+ * @return Illuminate\Database\Eloquent\Relations\HasMany
+ */
+public function issues(): HasMany
+{
+    return $this->hasMany(Issue::class);
 }
 }

--- a/src/database/migrations/2023_05_28_154926_create_issues_table.php
+++ b/src/database/migrations/2023_05_28_154926_create_issues_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('issues', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('description');
+            $table->enum('provider',['github','gitlab', 'bitbucket']);
+            $table->string('url');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('issues');
+    }
+};

--- a/src/database/migrations/2023_05_28_154926_create_issues_table.php
+++ b/src/database/migrations/2023_05_28_154926_create_issues_table.php
@@ -16,7 +16,6 @@ return new class extends Migration
         Schema::create('issues', function (Blueprint $table) {
             $table->id();
             $table->string('title');
-            $table->text('description');
             $table->enum('provider',['github','gitlab', 'bitbucket']);
             $table->string('url');
             $table->timestamps();

--- a/src/database/migrations/2023_05_28_161021_add_foreign_key_to_issues_table.php
+++ b/src/database/migrations/2023_05_28_161021_add_foreign_key_to_issues_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('issues', function (Blueprint $table) {
+            $table->unsignedBigInteger('message_id')->nullable();
+            $table->foreign('message_id')->references('id')->on('messages')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('issues', function (Blueprint $table) {
+            $table->dropForeign('issues_message_id_foreign');
+            $table->dropColumn('message_id');
+        });
+    }
+};

--- a/src/resources/views/ai-conversation.blade.php
+++ b/src/resources/views/ai-conversation.blade.php
@@ -52,7 +52,26 @@
             <!-- TODO: Make a component for the entire message card -->
             <div id="card-message-{{ $message->id }}" class="card border-0 shadow {{$message->status == 'sent' ? 'bg-dark-subtle' : 'bg-light-subtle'}}">
 
-                @if ($message->is_issue)
+                @if($message->issues()->count() > 0)
+                    <div class="card-header d-flex align-items-end justify-content-between
+                    " x-data="{
+                        selected_issue:null
+                    }">
+                        <div class="form-group grow-1">
+                            <label for="issues_for_message_{{$message->id}}">Linked Issues</label>
+                            <select class="form-control" name="issues_for_message_{{$message->id}}" id="issues_for_message_{{$message->id}}" x-model="selected_issue">
+                                <option value="#">Select an issue</option>
+                                @foreach ($message->issues()->get() as $issue)
+                                    <option value="{{ $issue->url }}">
+                                        <b>{{ ucfirst($issue->provider) }}: </b>{{$issue->title}}
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <a :href="selected_issue" class="btn btn-primary" target="_blank">Go</a>
+                    </div>
+                @endif
+                {{-- @if ($message->is_issue)
                 <div class="card-header">
 
                     <span>
@@ -64,7 +83,7 @@
                             {{$message->issue_url}}</a>
                     </span>
                 </div>
-                @endif
+                @endif --}}
 
                 <div class="card-body" contenteditable="false">
                     {!! Str::of($message->body)->markdown() !!}


### PR DESCRIPTION
Created the issue model that manages the different issues, dividing them by provider, and saving the link.
Now a message can handle multiple issues at a time and we can be redirected to the various issues.
Can be also helpful in the future when we're going to answer to already-opened issues.